### PR TITLE
ci: add the TruffleHog secret-scan workflow

### DIFF
--- a/.github/workflows/secret-scan.yml
+++ b/.github/workflows/secret-scan.yml
@@ -1,0 +1,24 @@
+name: Secret Scan
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    types: [opened, synchronize, reopened]
+  workflow_dispatch:
+
+jobs:
+  secret-scan:
+    name: TruffleHog Secret Scan
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Install truffleHog3
+        run: pip install truffleHog3
+
+      - name: Run secret scan
+        run: trufflehog3 filesystem .


### PR DESCRIPTION
Org-wide rollout of the house secret-scanning convention (Kevin, 2026-08-24): the TruffleHog CI workflow on every repo, copied verbatim from mt-hubspot-deploy-pipeline. The scan runs on this PR itself — a failure means this repo needs a scoped .trufflehog3.yml exclusion (see engineering-handbook#58 for the model) and will be triaged before merge.